### PR TITLE
resolve composer secure-http error.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "repositories": [
         {
             "type": "composer",
-            "url": "http://packagist.drupal-composer.org/"
+            "url": "https://packagist.drupal-composer.org/"
         },
 
         {


### PR DESCRIPTION
Composer throws error on install.

[Composer\Downloader\TransportException]  
  Your configuration does not allow connection to http://packagist.drupal-composer.org. See https://getcomposer.org/doc/06-config.md#secure-http for details.
